### PR TITLE
Add an hash function for circles

### DIFF
--- a/molly/Circle.py
+++ b/molly/Circle.py
@@ -170,6 +170,17 @@ class Circle(object):
         "complement of equals"
         return not self == other
 
+    def __hash__(self):
+        """
+        In python 3 it is not accepted to redefine __eq__ in a way that
+        a == b does not imply hash(a) == hash(b).
+        This is a very bad hash, but satisfies this condition.
+        """
+        h = round(self.pos.pos_x)
+        h += round(self.pos.pos_y)
+        h += round(self.radius)
+        return h
+
     @staticmethod
     def solve_quadratic(param_a, param_b, param_c):
         "solve a*x^2 + b*x + c = 0"

--- a/molly/tests/test_Circle.py
+++ b/molly/tests/test_Circle.py
@@ -279,6 +279,17 @@ class CircleTest(unittest.TestCase):
 
         self.assertTrue(circ.tangent_vector(pos, 1) == Vec2D(0, 1))
 
+    def test_equality_implies_same_hash(self):
+        """
+        Simple test to check that a == b implies hash(a) == hash(b)
+        """
+        a = Circle()
+        b = Circle()
+        a.pos.pos_x += 0.1 * Vec2D.EPSILON
+        a.pos.pos_y += 0.1 * Vec2D.EPSILON
+        a.radius += 0.1 * Vec2D.EPSILON
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is a first step in the direction of Python 3 compatibility. Since the equality operator is redefined for circles we need to provide a coherent hash function. The proposed one is not very random, which could lead to bad performance, but I don't think it will be an issue on the small set of object we will use.

Now I did not check if the objects used in collections are mutated, which is problem with this implementation.